### PR TITLE
add extension name to installation step 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Alternatively, press `Ctrl`+`Space` (Windows, Linux) or `Cmd`+`Space` (OSX) to a
 2. Launch Code
 3. From the command palette `Ctrl`-`Shift`-`P` (Windows, Linux) or `Cmd`-`Shift`-`P` (OSX)
 4. Select `Install Extension`
-5. Choose the extension
+5. Choose the extension `PWA-Tools`
 6. Reload Visual Studio Code
 
 ## Try it Out


### PR DESCRIPTION
It was a bit unclear what extension to install from the extension marketplace so calling out the name for this extension makes it helpful to find the right one.

## Purpose
* Add extension name to the installation guide so it's clear what extension to install for these tools

## What
* Add extension name to installation step 5

## What to Check
Verify that the following are valid
* The extension name is correct